### PR TITLE
refactor: split OpenAPI spec

### DIFF
--- a/api/public/combined.yml
+++ b/api/public/combined.yml
@@ -3,10 +3,180 @@ info:
   title: Thesis Management Software
   description: ""
   version: 0.0.1
+
 servers:
   - url: /api/v0
 
+tags:
+  - name: theses
+    description: Create and view theses
+  - name: comments
+    description: Post and view comments for theses
+  - name: likes
+    description: Track likes and dislikes of theses
+  - name: users
+    description: Manage users
+
 paths:
+  /users:
+    get:
+      summary: List all users
+      tags: ['users']
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/User'
+    post:
+      summary: Create one or more users
+      description: Calling this endpoint will also generate a registration token resource for every user.
+        Each registration token will be emailed to the respective user automatically.
+      tags: ['users']
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/User'
+                  registrationToken:
+                    $ref: '#/components/schemas/RegistrationToken'
+      responses:
+        '204':
+          description: Success. A list of all new user ids is returned. The order of users is retained from the request body array.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UserId'
+
+  /users/{userId}:
+    get:
+      summary: Get information about a specific user
+      tags: ['users']
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - name: registration_token # TODO: it might make sense to use `securitySchemes` and `security` here according to https://swagger.io/docs/specification/v3_0/describing-parameters/
+          in: query
+          description: A user's registration token. This allows requests to this endpoint for a user with the same registration_token without any authentication.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RegistrationToken'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: '#/components/schemas/User'
+        '401':
+          description: Either a `registration_token` was provided, but it is not authorized to access the user with the requested `id` or no authentication was provided at all.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: User with given `id` could not be found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      summary: Update information for a specific user
+      tags: ['users']
+      parameters:
+        - $ref: "#/components/parameters/userId"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: Success. The newly updated user information is returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: '#/components/schemas/User'
+        '404':
+          description: User with given `id` could not be found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Delete a specific user
+      tags: ['users']
+      parameters:
+        - $ref: "#/components/parameters/userId"
+      responses:
+        '204':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: object
+                    nullable: true
+        '404':
+          description: User with given `id` could not be found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /users/{userId}/regenerate_registration_token:
+    post:
+      summary: Regenerate a specific user's registration token
+      description: This endpoint is used to regenerate a new registration token for a specific user that exists already.
+        Calling this endpoint also causes the user to receive an email notification with the new registration token.
+      tags: ['users']
+      parameters:
+        - $ref: "#/components/parameters/userId"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: '#/components/schemas/RegistrationToken'
+        '404':
+          description: User with given `id` could not be found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: User has registered already.
+            Registered users are not eligible for new registration tokens Registered users are not eligible for new registration tokens.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /theses:
     get:
       summary: List theses summaries
@@ -44,7 +214,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
                 
   /theses/mine:
     get:
@@ -69,13 +239,6 @@ paths:
     put:
       summary: Update information for the thesis of the current user
       tags: ['theses']
-      parameters:
-        - name: id
-          in: path
-          description: The thesis id
-          required: true
-          schema:
-            $ref: '#/components/schemas/ThesisId'
       requestBody:
         content:
           application/json:
@@ -219,187 +382,6 @@ paths:
                 $ref: '#/components/schemas/Error'
       
 
-  /users:
-    get:
-      summary: List all users
-      tags: ['users']
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/User'
-    post:
-      summary: Create one or more users
-      description: Calling this endpoint will also generate a registration token resource for every user.
-        Each registration token will be emailed to the respective user automatically.
-      tags: ['users']
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                type: object
-                properties:
-                  user:
-                    $ref: '#/components/schemas/User'
-                  registrationToken:
-                    $ref: '#/components/schemas/RegistrationToken'
-      responses:
-        '204':
-          description: Success. A list of all new user ids is returned. The order of users is retained from the request body array.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/UserId'
-
-  /users/{id}?registration_token=registration_token:
-    get:
-      summary: Get information about a specific user
-      tags: ['users']
-      parameters:
-        - name: id
-          in: path
-          description: The user id
-          required: true
-          schema:
-            $ref: '#/components/schemas/UserId'
-        - name: registration_token
-          in: query
-          description: A user's registration token. This allows requests to this endpoint for a user with the same registration_token without any authentication.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RegistrationToken'
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    $ref: '#/components/schemas/User'
-        '401':
-          description: Either a `registration_token` was provided, but it is not authorized to access the user with the requested `id` or no authentication was provided at all.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '404':
-          description: User with given `id` could not be found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /users/{id}:
-    put:
-      summary: Update information for a specific user
-      tags: ['users']
-      parameters:
-        - name: id
-          in: path
-          description: The user id
-          required: true
-          schema:
-            $ref: "#/components/schemas/UserId"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/User'
-      responses:
-        '200':
-          description: Success. The newly updated user information is returned
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    $ref: '#/components/schemas/User'
-        '404':
-          description: User with given `id` could not be found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    delete:
-      summary: Delete a specific user
-      tags: ['users']
-      parameters:
-        - name: id
-          in: path
-          description: The user id
-          required: true
-          schema:
-            $ref: "#/components/schemas/UserId"
-      responses:
-        '204':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: object
-                    nullable: true
-        '404':
-          description: User with given `id` could not be found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /users/{id}/regenerate_registration_token:
-    post:
-      summary: Regenerate a specific user's registration token
-      description: This endpoint is used to regenerate a new registration token for a specific user that exists already.
-        Calling this endpoint also causes the user to receive an email notification with the new registration token.
-      tags: ['users']
-      parameters:
-        - name: id
-          in: path
-          description: The user id
-          required: true
-          schema:
-            $ref: "#/components/schemas/UserId"
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    $ref: '#/components/schemas/RegistrationToken'
-        '404':
-          description: User with given `id` could not be found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '409':
-          description: User has registered already.
-            Registered users are not eligible for new registration tokens Registered users are not eligible for new registration tokens.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
 
 components:
   schemas:
@@ -585,17 +567,19 @@ components:
         message:
           type: string
           example: "I really like your thesis. It sounds very interesting :)"
-tags:
-  - name: theses
-    description: Create and view theses
-  - name: users
-    description: Manage users
-  - name: comments
-    description: Post and view comments for theses
-  - name: likes
-    description: Track likes and dislikes of theses
 
-# MISSING
-# - send notification about start of validation phase to all supervisors
-# - likes/dislikes for theses
-
+  parameters:
+    thesisId:
+      name: thesisId
+      in: path
+      description: The thesis id
+      required: true
+      schema:
+        $ref: 'common.yml#/components/schemas/ThesisId'
+    userId:
+      name: userId
+      in: path
+      description: The user id
+      required: true
+      schema:
+        $ref: 'common.yml#/components/schemas/UserId'

--- a/api/public/common.yml
+++ b/api/public/common.yml
@@ -1,0 +1,204 @@
+# MISSING APIS
+# - send notification about start of validation phase to all supervisors
+# - like/dislike (alternatively accept/deny) feature for theses
+
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          example: "An error has occured."
+    Thesis:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ThesisId'
+        topic:
+          type: string
+          example: Thesis mangagement systems and their importance for universities
+        student:
+          type: object
+          properties:
+            id:
+              $ref: '#/components/schemas/UserId'
+            title:
+              type: string
+              example: Herr
+            firstName:
+              type: string
+              example: Max
+            lastName:
+              type: string
+              example: Mustermann
+            registrationNumber:
+              type: string
+              example: 1234567
+            course:
+              type: string
+              example: TINF22IT1
+        preparationPeriod:
+          type: object
+          properties:
+            from:
+              type: string
+              description: ISO-8601 timestamp
+              example: 2024-06-01T00:00:00+0000
+            to:
+              type: string
+              description: ISO-8601 timestamp
+              example: 2025-01-01T23:59:59+0000
+        partnerCompany:
+          type: object
+          properties:
+            name:
+              type: string
+              example: DHBW Innovation Center
+            address:
+              type: object
+              properties:
+                street:
+                  type: string
+                  example: Coblitzallee
+                zipCode:
+                  type: integer
+                  format: int32
+                  example: 68163
+                city:
+                  type: string
+                  example: Mannheim
+        operationalLocation:
+          type: object
+          properties:
+            companyName:
+              type: string
+              example: DHBW Innovation Center
+            department:
+              type: string
+              example: Administration
+            address:
+              type: object
+              properties:
+                street:
+                  type: string
+                  example: Coblitzallee
+                zipCode:
+                  type: integer
+                  format: int32
+                  example: 68163
+                city:
+                  type: string
+                  example: Mannheim
+                country:
+                  type: string
+                  example: Germany
+        inCompanySupervisor:
+          type: object
+          properties:
+            title:
+              type: string
+              example: Frau
+            academicTitle:
+              type: string
+              example: Prof. Dr.
+            firstName:
+              type: string
+              example: Erika
+            lastName:
+              type: string
+              example: Musterfrau
+            phoneNumber:
+              type: string
+              example: +49 0621000000
+            email:
+              type: string
+              example: erika.musterfrau@dhbw-mannheim.de
+            academicDegree:
+              type: string
+              example: "Master of Science"
+        
+        excludeSupervisorsFromCompanies:
+          type: array
+          items:
+            type: string
+          example: ["Universität Mannheim"]
+        
+        # TODO status
+    ThesisSummary:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/ThesisId"
+        title:
+          type: string
+        studentFirstName:
+          type: string
+        studentLastName:
+          type: string
+        # TODO status
+    User:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UserId'
+        registrationStatus:
+          type: object
+          readOnly: true
+          oneOf:
+            - type: object
+              properties:
+                pending:
+                  $ref: "#/components/schemas/RegistrationToken"
+            - type: object
+              properties:
+                completed:
+                  type: object
+                  nullable: true
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        role:
+          type: string
+          enum: [student, supervisor, secretary, administrator]
+    ThesisId:
+      type: integer
+      format: int64
+      example: 38729
+      readOnly: true
+    UserId:
+      type: integer
+      format: int64
+      example: 83791
+      readOnly: true
+    RegistrationToken:
+      type: string
+      example: "RANDOMIZED_TOKEN"
+      readOnly: true
+    Comment:
+      type: object
+      properties:
+        author:
+          $ref: '#/components/schemas/UserId'
+        message:
+          type: string
+          example: "I really like your thesis. It sounds very interesting :)"
+
+  parameters:
+    thesisId:
+      name: thesisId
+      in: path
+      description: The thesis id
+      required: true
+      schema:
+        $ref: 'common.yml#/components/schemas/ThesisId'
+    userId:
+      name: userId
+      in: path
+      description: The user id
+      required: true
+      schema:
+        $ref: 'common.yml#/components/schemas/UserId'

--- a/api/public/theses.yml
+++ b/api/public/theses.yml
@@ -1,0 +1,222 @@
+openapi: 3.0.3
+info:
+  title: Thesis Management Software (theses)
+  description: ""
+  version: 0.0.1
+
+servers:
+  - url: /api/v0
+
+tags:
+  - name: theses
+    description: Create and view theses
+  - name: comments
+    description: Post and view comments for theses
+  - name: likes
+    description: Track likes and dislikes of theses
+
+paths:
+  /theses:
+    get:
+      summary: List theses summaries
+      description: "Note: This endpoint might allow for filters in the future."
+      tags: ['theses']
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'common.yml#/components/schemas/ThesisSummary'
+    post:
+      summary: Create a new thesis for current user
+      tags: ['theses']
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'common.yml#/components/schemas/Thesis'
+      responses:
+        '201':
+          description: The thesis was created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/Thesis'
+        '409':
+          description: A thesis already exists for the current user. Only one thesis can exist per user.
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'
+                
+  /theses/mine:
+    get:
+      summary: Get information for the thesis of the current user
+      tags: ['theses']
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/Thesis'
+        '404':
+          description: No thesis could be found for the current user
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'
+    put:
+      summary: Update information for the thesis of the current user
+      tags: ['theses']
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'common.yml#/components/schemas/Thesis'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/Thesis'
+        '404':
+          description: Thesis with does not exist
+          content:
+            application/json:
+              schema: 
+                $ref: 'common.yml#/components/schemas/Error'
+
+  /theses/{id}:
+    get:
+      summary: Get information for a specific thesis
+      tags: ['theses']
+      parameters:
+        - name: id
+          in: path
+          description: The thesis id
+          required: true
+          schema:
+            $ref: "common.yml#/components/schemas/ThesisId"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/Thesis'
+        '404':
+          description: Thesis with does not exist
+          content:
+            application/json:
+              schema: 
+                $ref: 'common.yml#/components/schemas/Error'
+    put:
+      summary: Update information for a specific thesis
+      tags: ['theses']
+      parameters:
+        - name: id
+          in: path
+          description: The thesis id
+          required: true
+          schema:
+            $ref: 'common.yml#/components/schemas/ThesisId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'common.yml#/components/schemas/Thesis'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/Thesis'
+        '404':
+          description: Thesis with does not exist
+          content:
+            application/json:
+              schema: 
+                $ref: 'common.yml#/components/schemas/Error'
+  /theses/{id}/comments:
+    post:
+      summary: Post a new comment for a specific thesis
+      tags: ['comments']
+      parameters:
+        - name: id
+          in: path
+          description: The thesis id
+          required: true
+          schema:
+            $ref: 'common.yml#/components/schemas/ThesisId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'common.yml#/components/schemas/Comment'
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/Comment'
+        '404':
+          description: Thesis with does not exist
+          content:
+            application/json:
+              schema: 
+                $ref: 'common.yml#/components/schemas/Error'
+
+    get:
+      summary: List all comments for specific thesis
+      tags: ['comments']
+      parameters:
+        - name: id
+          in: path
+          description: The thesis id
+          required: true
+          schema:
+            $ref: 'common.yml#/components/schemas/ThesisId'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: array
+                    items:
+                      $ref: 'common.yml#/components/schemas/Comment'
+        '404':
+          description: Thesis with does not exist
+          content:
+            application/json:
+              schema: 
+                $ref: 'common.yml#/components/schemas/Error'
+      

--- a/api/public/users.yml
+++ b/api/public/users.yml
@@ -1,0 +1,173 @@
+openapi: 3.0.3
+info:
+  title: Thesis Management Software (users)
+  description: ""
+  version: 0.0.1
+
+servers:
+  - url: /api/v0
+
+tags:
+  - name: users
+    description: Manage users
+
+paths:
+  /users:
+    get:
+      summary: List all users
+      tags: ['users']
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: array
+                    items:
+                      $ref: 'common.yml#/components/schemas/User'
+    post:
+      summary: Create one or more users
+      description: Calling this endpoint will also generate a registration token resource for every user.
+        Each registration token will be emailed to the respective user automatically.
+      tags: ['users']
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  user:
+                    $ref: 'common.yml#/components/schemas/User'
+                  registrationToken:
+                    $ref: 'common.yml#/components/schemas/RegistrationToken'
+      responses:
+        '204':
+          description: Success. A list of all new user ids is returned. The order of users is retained from the request body array.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: array
+                    items:
+                      $ref: 'common.yml#/components/schemas/UserId'
+
+  /users/{userId}:
+    get:
+      summary: Get information about a specific user
+      tags: ['users']
+      parameters:
+        - $ref: "common.yml#/components/parameters/userId"
+        - name: registration_token # TODO: it might make sense to use `securitySchemes` and `security` here according to https://swagger.io/docs/specification/v3_0/describing-parameters/
+          in: query
+          description: A user's registration token. This allows requests to this endpoint for a user with the same registration_token without any authentication.
+          required: false
+          schema:
+            $ref: 'common.yml#/components/schemas/RegistrationToken'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/User'
+        '401':
+          description: Either a `registration_token` was provided, but it is not authorized to access the user with the requested `id` or no authentication was provided at all.
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'
+        '404':
+          description: User with given `id` could not be found
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'
+    put:
+      summary: Update information for a specific user
+      tags: ['users']
+      parameters:
+        - $ref: "common.yml#/components/parameters/userId"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'common.yml#/components/schemas/User'
+      responses:
+        '200':
+          description: Success. The newly updated user information is returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/User'
+        '404':
+          description: User with given `id` could not be found
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'
+    delete:
+      summary: Delete a specific user
+      tags: ['users']
+      parameters:
+        - $ref: "common.yml#/components/parameters/userId"
+      responses:
+        '204':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: object
+                    nullable: true
+        '404':
+          description: User with given `id` could not be found.
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'
+  /users/{userId}/regenerate_registration_token:
+    post:
+      summary: Regenerate a specific user's registration token
+      description: This endpoint is used to regenerate a new registration token for a specific user that exists already.
+        Calling this endpoint also causes the user to receive an email notification with the new registration token.
+      tags: ['users']
+      parameters:
+        - $ref: "common.yml#/components/parameters/userId"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    $ref: 'common.yml#/components/schemas/RegistrationToken'
+        '404':
+          description: User with given `id` could not be found.
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'
+        '409':
+          description: User has registered already.
+            Registered users are not eligible for new registration tokens Registered users are not eligible for new registration tokens.
+          content:
+            application/json:
+              schema:
+                $ref: 'common.yml#/components/schemas/Error'


### PR DESCRIPTION
This PR splits our OpenAPI specification into 3 files:
- `common.yml` contains common types and parameters 
- `theses.yml` contains the API for the thesis service
- `users.yml` contains the API for the user service

Also there is `combined.yml`: It contains all of these APIs combined into a single file (manually combined, as I couldn't find a proper merge tool). We need this file, so we can inspect our API with Swagger UI (it doesn't have multi-file support).

Note that we only have public-facing APIs as of now.
I also added another directory for private APIs `api/internal/`, which are not exposed to the public (e.g. the the notification service).

