### PR TITLE
feat: Update keycloak group naming to match API spec

### DIFF
--- a/keycloak/thesis-management-realm.json
+++ b/keycloak/thesis-management-realm.json
@@ -419,8 +419,8 @@
   "groups": [
     {
       "id": "7f66fa3c-c849-4b6e-bfb9-d11be8d3fd16",
-      "name": "Administrator",
-      "path": "/Administrator",
+      "name": "administrator",
+      "path": "/administrator",
       "subGroups": [],
       "attributes": {},
       "realmRoles": [],
@@ -428,8 +428,8 @@
     },
     {
       "id": "8fae112e-f42f-426f-83a2-974e82f16f51",
-      "name": "Student",
-      "path": "/Student",
+      "name": "student",
+      "path": "/student",
       "subGroups": [],
       "attributes": {},
       "realmRoles": [],
@@ -437,8 +437,17 @@
     },
     {
       "id": "bd4715a0-dd84-4a19-bd74-8f845191d677",
-      "name": "Teacher",
-      "path": "/Teacher",
+      "name": "supervisor",
+      "path": "/supervisor",
+      "subGroups": [],
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {}
+    },
+    {
+      "id": "595e13a7-8796-4a47-b1e1-34b35449e2ad",
+      "name": "secretary",
+      "path": "/secretary",
       "subGroups": [],
       "attributes": {},
       "realmRoles": [],

--- a/keycloak/thesis-management-users-0.json
+++ b/keycloak/thesis-management-users-0.json
@@ -7,14 +7,18 @@
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,
-    "firstName" : "",
-    "lastName" : "",
+    "firstName" : "alberto",
+    "lastName" : "user1",
+    "email": "alberto@test.de",
     "credentials" : [ ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-test-realm" ],
     "notBefore" : 0,
-    "groups" : [ "/Administrator" ]
+    "groups" : [ "/administrator" ],
+    "attributes": { 
+        "registration_complete": [true]
+    }
   },
   {
     "id" : "846aca25-d633-438c-8ccd-2d8fb2364c61",
@@ -23,14 +27,19 @@
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,
-    "firstName" : "",
-    "lastName" : "",
+    "firstName" : "franz",
+    "lastName" : "user2",
+    "email": "franz@test.de",
     "credentials" : [ ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-test-realm" ],
     "notBefore" : 0,
-    "groups" : [ "/Student" ]
+    "groups" : [ "/student" ],
+    "attributes": { 
+        "registration_complete": [false],
+        "registration_token": ["1234"]
+    }
   },
   {
     "id" : "810f0803-2b1b-422b-8613-14d6b215664a",
@@ -39,13 +48,18 @@
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,
-    "firstName" : "",
-    "lastName" : "",
+    "firstName" : "gonk",
+    "lastName" : "droid",
+    "email": "gonk_droid@test.de",
     "credentials" : [ ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-test-realm" ],
     "notBefore" : 0,
-    "groups" : [ "/Teacher" ]
+    "groups" : [ "/supervisor" ],
+    "attributes": { 
+        "registration_complete": [false],
+        "registration_token": ["4321"]
+    }
   }]
 }


### PR DESCRIPTION
This PR updates the names of the groups in the Thesis Management Realm in Keycloak. The current group naming does not match the API spec.